### PR TITLE
requestAnimationFrame for 2014

### DIFF
--- a/app/requestAnimationFrame.js
+++ b/app/requestAnimationFrame.js
@@ -35,9 +35,9 @@ end old Firefox */
                 var currTime = new Date().getTime();
                 var timeToCall = Math.max( 0, 16 - ( currTime - lastTime ) );
                 var id = window.setTimeout( function() {
-                    callback( currTime + timeToCall );
-                },
-                timeToCall );
+                        callback( currTime + timeToCall );
+                    },
+                    timeToCall );
                 lastTime = currTime + timeToCall;
                 return id;  // return the id for cancellation capabilities
             };


### PR DESCRIPTION
Never needed [ms or o prefixes](http://dev.opera.com/articles/view/better-performance-with-requestanimationframe/) for released browsers.  Even [Paul Irish](http://www.paulirish.com/2011/requestanimationframe-for-smart-animating/) dropped them.  Very rarely need [moz prefix](http://caniuse.com/requestanimationframe), so that is included, but commented out by default.

Therefore, don't need a prefix loop either.

Moved `var lastTime = 0;` inside the `else` fallback (about 15% of browsers); does not need to be global.
